### PR TITLE
feat: add events page and mobile nav

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,24 @@
+import Navbar from "@/components/Navbar";
+
+export default function Events(){
+  return (
+    <main>
+      <Navbar />
+      <section className="container py-16">
+        <h1 className="h1">Events & Sponsorships</h1>
+        <div className="grid md:grid-cols-3 gap-6 mt-8">
+          {[
+            {title:'Exhibitions', desc:'Showcasing fine craftsmanship across cities'},
+            {title:'Lucky Draws', desc:'Exciting prizes for our valued patrons'},
+            {title:'Local Sponsorships', desc:'Supporting community events and causes'}
+          ].map(x => (
+            <div key={x.title} className="rounded-2xl bg-white shadow-soft p-6">
+              <div className="text-maroon font-semibold text-lg">{x.title}</div>
+              <p className="p mt-2 text-charcoal/80">{x.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,17 +1,26 @@
 export default function Navbar() {
+  const items = ['About','Schemes','Catalogue','Events','Contact'];
   return (
     <header className="sticky top-0 z-50 bg-ivory/80 backdrop-blur">
       <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
         <a href="/" className="text-maroon h2 font-semibold">Chiddarwar Jewellers</a>
         <nav className="hidden md:flex gap-8">
-          {['About','Schemes','Catalogue','Events','Contact'].map(i=>(
+          {items.map(i=>(
             <a key={i} href={`/${i.toLowerCase()}`} className="p font-medium hover:text-maroon transition">{i}</a>
           ))}
         </nav>
         <div className="flex items-center gap-3">
-          <a href="https://wa.me/91XXXXXXXXXX" className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90">WhatsApp</a>
+          <a href="https://wa.me/91XXXXXXXXXX" className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90">
+WhatsApp</a>
         </div>
       </div>
+      <nav className="md:hidden border-t border-ivory/40">
+        <div className="mx-auto max-w-6xl px-4 py-3 flex gap-6 overflow-x-auto">
+          {items.map(i=>(
+            <a key={i} href={`/${i.toLowerCase()}`} className="p text-sm font-medium whitespace-nowrap hover:text-maroon transition">{i}</a>
+          ))}
+        </div>
+      </nav>
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- add `/events` page highlighting exhibitions, lucky draws, and local sponsorships
- update navbar with shared link set and mobile navigation so Events is reachable on all devices

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint configuration prompt; lint not executed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dceba27c8333b45a1d993bae2b21