### PR TITLE
Add SEO metadata keywords and canonical URL

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,10 +4,20 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Chiddarwar Jewellers — Purity & Trust Since 2002",
   description: "Premium jewellery in Pusad. 916 hallmark guarantee, exquisite variety, heartfelt service.",
+  keywords: [
+    "Chiddarwar Jewellers",
+    "gold jewellery",
+    "Pusad",
+    "916 hallmark",
+    "silver ornaments"
+  ],
   openGraph: {
     title: "Chiddarwar Jewellers",
     description: "Purity & Trust Since 2002",
     type: "website"
+  },
+  alternates: {
+    canonical: "https://chiddarwarjewellers.com"
   }
 };
 


### PR DESCRIPTION
## Summary
- add keyword tags to metadata for SEO
- specify canonical URL in metadata alternates

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c5dcf89f4883339bf98d680466bead