### PR TITLE
Replace WhatsApp placeholder with actual API number

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@
 
 ## Customize
 - Replace `/public/hero.jpg` and images in `/public/collections/` with real photos.
-- Update WhatsApp number (search for `91XXXXXXXXXX`).
+- WhatsApp number set to `917888047331`.
 - Edit copy in `app` pages.
 - Colors live in `tailwind.config.ts`.

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -13,7 +13,7 @@ export default function Contact(){
             width="100%" height="360" style={{border:0}} loading="lazy"></iframe>
         </div>
       </section>
-      <a href="https://wa.me/91XXXXXXXXXX"
+      <a href="https://wa.me/917888047331"
          className="fixed bottom-5 right-5 px-5 py-3 rounded-full bg-maroon text-ivory shadow-soft">WhatsApp Us</a>
     </main>
   )

--- a/chiddarwar-premium-starter-english/README.md
+++ b/chiddarwar-premium-starter-english/README.md
@@ -15,6 +15,6 @@
 
 ## Customize
 - Replace `/public/hero.jpg` and images in `/public/collections/` with real photos.
-- Update WhatsApp number (search for `91XXXXXXXXXX`).
+- WhatsApp number set to `917888047331`.
 - Edit copy in `app` pages.
 - Colors live in `tailwind.config.ts`.

--- a/chiddarwar-premium-starter-english/app/contact/page.tsx
+++ b/chiddarwar-premium-starter-english/app/contact/page.tsx
@@ -13,7 +13,7 @@ export default function Contact(){
             width="100%" height="360" style={{border:0}} loading="lazy"></iframe>
         </div>
       </section>
-      <a href="https://wa.me/91XXXXXXXXXX"
+      <a href="https://wa.me/917888047331"
          className="fixed bottom-5 right-5 px-5 py-3 rounded-full bg-maroon text-ivory shadow-soft">WhatsApp Us</a>
     </main>
   )

--- a/chiddarwar-premium-starter-english/components/Navbar.tsx
+++ b/chiddarwar-premium-starter-english/components/Navbar.tsx
@@ -9,7 +9,7 @@ export default function Navbar() {
           ))}
         </nav>
         <div className="flex items-center gap-3">
-          <a href="https://wa.me/91XXXXXXXXXX" className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90">WhatsApp</a>
+            <a href="https://wa.me/917888047331" className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90">WhatsApp</a>
         </div>
       </div>
     </header>

--- a/chiddarwar-premium-starter-english/components/ProductCard.tsx
+++ b/chiddarwar-premium-starter-english/components/ProductCard.tsx
@@ -4,7 +4,7 @@ export default function ProductCard({img, title}:{img:string; title:string}){
       <img src={img} alt={title} className="h-72 w-full object-cover group-hover:scale-[1.02] transition" />
       <div className="p-4 flex items-center justify-between">
         <div className="p font-medium">{title}</div>
-        <a href="https://wa.me/91XXXXXXXXXX"
+        <a href="https://wa.me/917888047331"
            className="text-sm px-3 py-1.5 rounded-full bg-maroon text-ivory">Enquire</a>
       </div>
     </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -9,7 +9,7 @@ export default function Navbar() {
           ))}
         </nav>
         <div className="flex items-center gap-3">
-          <a href="https://wa.me/91XXXXXXXXXX" className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90">WhatsApp</a>
+            <a href="https://wa.me/917888047331" className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90">WhatsApp</a>
         </div>
       </div>
     </header>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -4,7 +4,7 @@ export default function ProductCard({img, title}:{img:string; title:string}){
       <img src={img} alt={title} className="h-72 w-full object-cover group-hover:scale-[1.02] transition" />
       <div className="p-4 flex items-center justify-between">
         <div className="p font-medium">{title}</div>
-        <a href="https://wa.me/91XXXXXXXXXX"
+        <a href="https://wa.me/917888047331"
            className="text-sm px-3 py-1.5 rounded-full bg-maroon text-ivory">Enquire</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace placeholder `91XXXXXXXXXX` with `917888047331` across components, contact page, and docs
- document new WhatsApp contact number in README files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `curl -I https://wa.me/917888047331`


------
https://chatgpt.com/codex/tasks/task_e_68c5dceee7208333bce81d05edda4614