### PR TITLE
Add basic i18n with English and Marathi translations

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,17 +1,17 @@
-import Navbar from "@/components/Navbar";
+"use client";
 
-export default function About(){
+import Navbar from "@/components/Navbar";
+import { useI18n } from "@/lib/i18n";
+
+export default function About() {
+  const { t } = useI18n();
   return (
     <main>
       <Navbar />
       <section className="container py-16">
-        <h1 className="h1">About Us</h1>
-        <p className="p mt-6 max-w-3xl">
-          Founded by Bhagwat Chiddarwar in 2002, we brought 916 hallmark purity to Pusad,
-          introduced diamonds in 2012, and hosted the city’s first diamond exhibition in 2014
-          with a car as the grand prize. We continue to serve with trust, craftsmanship, and care.
-        </p>
+        <h1 className="h1">{t("about.title")}</h1>
+        <p className="p mt-6 max-w-3xl">{t("about.body")}</p>
       </section>
     </main>
-  )
+  );
 }

--- a/app/catalogue/page.tsx
+++ b/app/catalogue/page.tsx
@@ -1,19 +1,23 @@
+"use client";
+
 import Navbar from "@/components/Navbar";
 import ProductCard from "@/components/ProductCard";
+import { useI18n } from "@/lib/i18n";
 
-export default function Catalogue(){
+export default function Catalogue() {
+  const { t } = useI18n();
   return (
     <main>
       <Navbar />
       <section className="container py-16">
-        <h1 className="h1 mb-8">Catalogue</h1>
+        <h1 className="h1 mb-8">{t("catalogue.title")}</h1>
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          <ProductCard img="/collections/bridal.jpg" title="Bridal" />
-          <ProductCard img="/collections/antique.jpg" title="Antique" />
-          <ProductCard img="/collections/diamond.jpg" title="Diamond" />
+          <ProductCard img="/collections/bridal.jpg" title={t("products.bridal")} />
+          <ProductCard img="/collections/antique.jpg" title={t("products.antique")} />
+          <ProductCard img="/collections/diamond.jpg" title={t("products.diamond")} />
         </div>
-        <p className="p mt-8 text-charcoal/80">Tap “Enquire” to WhatsApp us for details, pricing, and availability.</p>
+        <p className="p mt-8 text-charcoal/80">{t("catalogue.info")}</p>
       </section>
     </main>
-  )
+  );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,20 +1,35 @@
-import Navbar from "@/components/Navbar";
+"use client";
 
-export default function Contact(){
+import Navbar from "@/components/Navbar";
+import { useI18n } from "@/lib/i18n";
+
+export default function Contact() {
+  const { t } = useI18n();
   return (
     <main>
       <Navbar />
       <section className="container py-16">
-        <h1 className="h1">Contact</h1>
-        <p className="p mt-6">Call: +91 XXXXX XXXXX<br/>Email: info@chiddarwarjewellers.com</p>
+        <h1 className="h1">{t("contact.title")}</h1>
+        <p
+          className="p mt-6"
+          dangerouslySetInnerHTML={{ __html: t("contact.info").replace('\n', '<br/>') }}
+        />
         <div className="mt-8">
           <iframe
             src="https://maps.google.com/maps?q=Pusad%20Maharashtra&t=&z=13&ie=UTF8&iwloc=&output=embed"
-            width="100%" height="360" style={{border:0}} loading="lazy"></iframe>
+            width="100%"
+            height="360"
+            style={{ border: 0 }}
+            loading="lazy"
+          ></iframe>
         </div>
       </section>
-      <a href="https://wa.me/91XXXXXXXXXX"
-         className="fixed bottom-5 right-5 px-5 py-3 rounded-full bg-maroon text-ivory shadow-soft">WhatsApp Us</a>
+      <a
+        href="https://wa.me/91XXXXXXXXXX"
+        className="fixed bottom-5 right-5 px-5 py-3 rounded-full bg-maroon text-ivory shadow-soft"
+      >
+        {t("contact.whatsapp")}
+      </a>
     </main>
-  )
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import { I18nProvider } from "@/lib/i18n";
 
 export const metadata: Metadata = {
   title: "Chiddarwar Jewellers — Purity & Trust Since 2002",
@@ -14,7 +15,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <I18nProvider>{children}</I18nProvider>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,32 +1,42 @@
+"use client";
+
 import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
 import SchemeCards from "@/components/SchemeCards";
 import ProductCard from "@/components/ProductCard";
+import { useI18n } from "@/lib/i18n";
 
 export default function Home() {
+  const { t } = useI18n();
   return (
     <main>
       <Navbar />
       <Hero />
       <section className="mx-auto max-w-6xl px-6 py-16">
-        <h2 className="h2 mb-6">Featured Collections</h2>
+        <h2 className="h2 mb-6">{t("home.featured")}</h2>
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          <ProductCard img="/collections/bridal.jpg" title="Bridal" />
-          <ProductCard img="/collections/antique.jpg" title="Antique" />
-          <ProductCard img="/collections/diamond.jpg" title="Diamond" />
+          <ProductCard img="/collections/bridal.jpg" title={t("products.bridal")} />
+          <ProductCard img="/collections/antique.jpg" title={t("products.antique")} />
+          <ProductCard img="/collections/diamond.jpg" title={t("products.diamond")} />
         </div>
       </section>
       <SchemeCards />
       <footer className="border-t border-black/10">
         <div className="mx-auto max-w-6xl px-6 py-10 grid md:grid-cols-3 gap-8">
-          <div><div className="h2 text-maroon">Chiddarwar Jewellers</div>
-            <p className="p mt-2">Purity & Trust Since 2002</p></div>
-          <div><div className="font-semibold">Visit Us</div>
-            <p className="p mt-2">Pusad, Maharashtra • 10:30am – 8:30pm</p></div>
-          <div><div className="font-semibold">Contact</div>
-            <p className="p mt-2">+91 XXXXX XXXXX • info@chiddarwarjewellers.com</p></div>
+          <div>
+            <div className="h2 text-maroon">{t("home.footerTitle")}</div>
+            <p className="p mt-2">{t("home.footerTagline")}</p>
+          </div>
+          <div>
+            <div className="font-semibold">{t("home.visitUs")}</div>
+            <p className="p mt-2">{t("home.visitInfo")}</p>
+          </div>
+          <div>
+            <div className="font-semibold">{t("home.contact")}</div>
+            <p className="p mt-2">{t("home.contactInfo")}</p>
+          </div>
         </div>
       </footer>
     </main>
-  )
+  );
 }

--- a/app/schemes/page.tsx
+++ b/app/schemes/page.tsx
@@ -1,17 +1,22 @@
-import Navbar from "@/components/Navbar";
+"use client";
 
-export default function Schemes(){
+import Navbar from "@/components/Navbar";
+import { useI18n } from "@/lib/i18n";
+
+export default function Schemes() {
+  const { t } = useI18n();
+  const items = [
+    { title: t("schemeCards.dhanLaxmi"), desc: t("schemeCards.dhanLaxmiDesc"), href: "/schemes/dhan-laxmi" },
+    { title: t("schemeCards.digitalGold"), desc: t("schemeCards.digitalGoldDesc"), href: "/schemes/digital-gold" },
+    { title: t("schemeCards.loyaltyPoints"), desc: t("schemeCards.loyaltyPointsDesc"), href: "/schemes/loyalty" }
+  ];
   return (
     <main>
       <Navbar />
       <section className="container py-16">
-        <h1 className="h1">Our Schemes</h1>
+        <h1 className="h1">{t("schemesPage.title")}</h1>
         <div className="grid md:grid-cols-3 gap-6 mt-8">
-          {[
-            {title:'Dhan Laxmi', desc:'Scratch & Win + Lucky Draw', href:'/schemes/dhan-laxmi'},
-            {title:'Digital Gold', desc:'Buy online, redeem in-store', href:'/schemes/digital-gold'},
-            {title:'Loyalty Points', desc:'Earn on every purchase', href:'/schemes/loyalty'}
-          ].map(x => (
+          {items.map((x) => (
             <a key={x.title} href={x.href} className="rounded-2xl bg-white shadow-soft p-6 hover:shadow-lg transition">
               <div className="text-maroon font-semibold text-lg">{x.title}</div>
               <p className="p mt-2 text-charcoal/80">{x.desc}</p>
@@ -20,5 +25,5 @@ export default function Schemes(){
         </div>
       </section>
     </main>
-  )
+  );
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,18 +1,30 @@
+"use client";
+
+import { useI18n } from "@/lib/i18n";
+
 export default function Hero() {
+  const { t } = useI18n();
   return (
     <section className="relative">
-      <img src="/hero.jpg" alt="Heritage gold set" className="w-full h-[62vh] object-cover" />
+      <img src="/hero.jpg" alt={t("hero.alt")}
+        className="w-full h-[62vh] object-cover" />
       <div className="absolute inset-0 bg-black/35" />
       <div className="absolute inset-0 flex items-center">
         <div className="mx-auto max-w-6xl px-6 text-white">
-          <h1 className="h1">Legacy in <span className="gold-gradient">Every Carat</span></h1>
-          <p className="p mt-4 max-w-xl">Since 2002—916 hallmark purity, exquisite variety, and heartfelt service in Pusad.</p>
+          <h1 className="h1">
+            {t("hero.heading1")} <span className="gold-gradient">{t("hero.heading2")}</span>
+          </h1>
+          <p className="p mt-4 max-w-xl">{t("hero.tagline")}</p>
           <div className="mt-8 flex gap-3">
-            <a href="/contact" className="px-6 py-3 rounded-full bg-gold text-charcoal font-medium">Visit Store</a>
-            <a href="/schemes" className="px-6 py-3 rounded-full border border-white/70 hover:bg-white/10">Explore Schemes</a>
+            <a href="/contact" className="px-6 py-3 rounded-full bg-gold text-charcoal font-medium">
+              {t("hero.visit")}
+            </a>
+            <a href="/schemes" className="px-6 py-3 rounded-full border border-white/70 hover:bg-white/10">
+              {t("hero.schemes")}
+            </a>
           </div>
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,17 +1,36 @@
+"use client";
+
+import { useI18n } from "@/lib/i18n";
+
 export default function Navbar() {
+  const { t, locale, setLocale } = useI18n();
+  const items = ["about", "schemes", "catalogue", "events", "contact"];
   return (
     <header className="sticky top-0 z-50 bg-ivory/80 backdrop-blur">
       <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
-        <a href="/" className="text-maroon h2 font-semibold">Chiddarwar Jewellers</a>
+        <a href="/" className="text-maroon h2 font-semibold">{t("nav.title")}</a>
         <nav className="hidden md:flex gap-8">
-          {['About','Schemes','Catalogue','Events','Contact'].map(i=>(
-            <a key={i} href={`/${i.toLowerCase()}`} className="p font-medium hover:text-maroon transition">{i}</a>
+          {items.map((i) => (
+            <a key={i} href={`/${i}`} className="p font-medium hover:text-maroon transition">
+              {t(`nav.${i}`)}
+            </a>
           ))}
         </nav>
         <div className="flex items-center gap-3">
-          <a href="https://wa.me/91XXXXXXXXXX" className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90">WhatsApp</a>
+          <a
+            href="https://wa.me/91XXXXXXXXXX"
+            className="px-4 py-2 rounded-full bg-maroon text-ivory text-sm hover:opacity-90"
+          >
+            {t("nav.whatsapp")}
+          </a>
+          <button
+            onClick={() => setLocale(locale === "en" ? "mr" : "en")}
+            className="text-sm font-medium underline"
+          >
+            {locale === "en" ? "MR" : "EN"}
+          </button>
         </div>
       </div>
     </header>
-  )
+  );
 }

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,12 +1,25 @@
-export default function ProductCard({img, title}:{img:string; title:string}){
+"use client";
+
+import { useI18n } from "@/lib/i18n";
+
+export default function ProductCard({ img, title }: { img: string; title: string }) {
+  const { t } = useI18n();
   return (
     <div className="group rounded-2xl overflow-hidden bg-white shadow-soft">
-      <img src={img} alt={title} className="h-72 w-full object-cover group-hover:scale-[1.02] transition" />
+      <img
+        src={img}
+        alt={title}
+        className="h-72 w-full object-cover group-hover:scale-[1.02] transition"
+      />
       <div className="p-4 flex items-center justify-between">
         <div className="p font-medium">{title}</div>
-        <a href="https://wa.me/91XXXXXXXXXX"
-           className="text-sm px-3 py-1.5 rounded-full bg-maroon text-ivory">Enquire</a>
+        <a
+          href="https://wa.me/91XXXXXXXXXX"
+          className="text-sm px-3 py-1.5 rounded-full bg-maroon text-ivory"
+        >
+          {t("products.enquire")}
+        </a>
       </div>
     </div>
-  )
+  );
 }

--- a/components/SchemeCards.tsx
+++ b/components/SchemeCards.tsx
@@ -1,21 +1,25 @@
-const items = [
-  {title:'Dhan Laxmi', desc:'Scratch & Win + Lucky Draw', href:'/schemes/dhan-laxmi'},
-  {title:'Digital Gold', desc:'Buy online, redeem in-store', href:'/schemes/digital-gold'},
-  {title:'Loyalty Points', desc:'Earn on every purchase', href:'/schemes/loyalty'},
-]
-export default function SchemeCards(){
+"use client";
+
+import { useI18n } from "@/lib/i18n";
+
+export default function SchemeCards() {
+  const { t } = useI18n();
+  const items = [
+    { title: t("schemeCards.dhanLaxmi"), desc: t("schemeCards.dhanLaxmiDesc"), href: "/schemes/dhan-laxmi" },
+    { title: t("schemeCards.digitalGold"), desc: t("schemeCards.digitalGoldDesc"), href: "/schemes/digital-gold" },
+    { title: t("schemeCards.loyaltyPoints"), desc: t("schemeCards.loyaltyPointsDesc"), href: "/schemes/loyalty" }
+  ];
   return (
     <section className="mx-auto max-w-6xl px-6 py-16">
-      <h2 className="h2 mb-8">Our Schemes</h2>
+      <h2 className="h2 mb-8">{t("schemeCards.heading")}</h2>
       <div className="grid md:grid-cols-3 gap-6">
-        {items.map(i=>(
-          <a key={i.title} href={i.href}
-             className="rounded-2xl bg-white shadow-soft p-6 hover:shadow-lg transition">
+        {items.map((i) => (
+          <a key={i.title} href={i.href} className="rounded-2xl bg-white shadow-soft p-6 hover:shadow-lg transition">
             <div className="text-maroon font-semibold text-lg">{i.title}</div>
             <p className="p mt-2 text-charcoal/80">{i.desc}</p>
           </a>
         ))}
       </div>
     </section>
-  )
+  );
 }

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+import en from '@/locales/en.json';
+import mr from '@/locales/mr.json';
+
+export type Locale = 'en' | 'mr';
+const dictionaries: Record<Locale, Record<string, string>> = { en, mr };
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue>({
+  locale: 'en',
+  setLocale: () => {},
+  t: (key: string) => key,
+});
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocale] = useState<Locale>('en');
+  const t = (key: string) => dictionaries[locale][key] || key;
+  return (
+    <I18nContext.Provider value={{ locale, setLocale, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,49 @@
+{
+  "nav.title": "Chiddarwar Jewellers",
+  "nav.about": "About",
+  "nav.schemes": "Schemes",
+  "nav.catalogue": "Catalogue",
+  "nav.events": "Events",
+  "nav.contact": "Contact",
+  "nav.whatsapp": "WhatsApp",
+
+  "hero.alt": "Heritage gold set",
+  "hero.heading1": "Legacy in",
+  "hero.heading2": "Every Carat",
+  "hero.tagline": "Since 2002—916 hallmark purity, exquisite variety, and heartfelt service in Pusad.",
+  "hero.visit": "Visit Store",
+  "hero.schemes": "Explore Schemes",
+
+  "home.featured": "Featured Collections",
+  "home.footerTitle": "Chiddarwar Jewellers",
+  "home.footerTagline": "Purity & Trust Since 2002",
+  "home.visitUs": "Visit Us",
+  "home.visitInfo": "Pusad, Maharashtra • 10:30am – 8:30pm",
+  "home.contact": "Contact",
+  "home.contactInfo": "+91 XXXXX XXXXX • info@chiddarwarjewellers.com",
+
+  "products.bridal": "Bridal",
+  "products.antique": "Antique",
+  "products.diamond": "Diamond",
+  "products.enquire": "Enquire",
+
+  "schemeCards.heading": "Our Schemes",
+  "schemeCards.dhanLaxmi": "Dhan Laxmi",
+  "schemeCards.dhanLaxmiDesc": "Scratch & Win + Lucky Draw",
+  "schemeCards.digitalGold": "Digital Gold",
+  "schemeCards.digitalGoldDesc": "Buy online, redeem in-store",
+  "schemeCards.loyaltyPoints": "Loyalty Points",
+  "schemeCards.loyaltyPointsDesc": "Earn on every purchase",
+
+  "catalogue.title": "Catalogue",
+  "catalogue.info": "Tap “Enquire” to WhatsApp us for details, pricing, and availability.",
+
+  "contact.title": "Contact",
+  "contact.info": "Call: +91 XXXXX XXXXX\nEmail: info@chiddarwarjewellers.com",
+  "contact.whatsapp": "WhatsApp Us",
+
+  "about.title": "About Us",
+  "about.body": "Founded by Bhagwat Chiddarwar in 2002, we brought 916 hallmark purity to Pusad, introduced diamonds in 2012, and hosted the city’s first diamond exhibition in 2014 with a car as the grand prize. We continue to serve with trust, craftsmanship, and care.",
+
+  "schemesPage.title": "Our Schemes"
+}

--- a/locales/mr.json
+++ b/locales/mr.json
@@ -1,0 +1,49 @@
+{
+  "nav.title": "चिद्दरवर ज्वेलर्स",
+  "nav.about": "आमच्याबद्दल",
+  "nav.schemes": "योजना",
+  "nav.catalogue": "कॅटलॉग",
+  "nav.events": "कार्यक्रम",
+  "nav.contact": "संपर्क",
+  "nav.whatsapp": "व्हॉट्सअॅप",
+
+  "hero.alt": "वारसा सुवर्ण संच",
+  "hero.heading1": "वारसा",
+  "hero.heading2": "प्रत्येक कॅरटमध्ये",
+  "hero.tagline": "२००२ पासून—९१६ हॉलमार्क शुद्धता, उत्कृष्ट विविधता आणि पुसेदमध्ये मनापासून सेवा.",
+  "hero.visit": "दुकानाला भेट द्या",
+  "hero.schemes": "योजना पाहा",
+
+  "home.featured": "वैशिष्ट्यपूर्ण संग्रह",
+  "home.footerTitle": "चिद्दरवर ज्वेलर्स",
+  "home.footerTagline": "२००२ पासून शुद्धता आणि विश्वास",
+  "home.visitUs": "आम्हाला भेट द्या",
+  "home.visitInfo": "पुसेद, महाराष्ट्र • १०:३०am – ८:३०pm",
+  "home.contact": "संपर्क",
+  "home.contactInfo": "+91 XXXXX XXXXX • info@chiddarwarjewellers.com",
+
+  "products.bridal": "वधू",
+  "products.antique": "प्राचीन",
+  "products.diamond": "हिरा",
+  "products.enquire": "चौकशी करा",
+
+  "schemeCards.heading": "आमच्या योजना",
+  "schemeCards.dhanLaxmi": "धन लक्ष्मी",
+  "schemeCards.dhanLaxmiDesc": "स्क्रॅच आणि विन + लकी ड्रॉ",
+  "schemeCards.digitalGold": "डिजिटल गोल्ड",
+  "schemeCards.digitalGoldDesc": "ऑनलाईन खरेदी, दुकानात रिडीम",
+  "schemeCards.loyaltyPoints": "निष्ठा पॉइंट्स",
+  "schemeCards.loyaltyPointsDesc": "प्रत्येक खरेदीवर कमवा",
+
+  "catalogue.title": "कॅटलॉग",
+  "catalogue.info": "तपशील, किंमत आणि उपलब्धतेसाठी व्हॉट्सअॅपवर “चौकशी करा” टॅप करा.",
+
+  "contact.title": "संपर्क",
+  "contact.info": "कॉल: +91 XXXXX XXXXX\nईमेल: info@chiddarwarjewellers.com",
+  "contact.whatsapp": "व्हॉट्सअॅप करा",
+
+  "about.title": "आमच्याबद्दल",
+  "about.body": "भगवत चिद्दरवर यांनी २००२ मध्ये स्थापना केली; आम्ही ९१६ हॉलमार्क शुद्धता पुसेदमध्ये आणली, २०१२ मध्ये हिरे सादर केले आणि २०१४ मध्ये शहरातील पहिली हिर्‍यांची प्रदर्शनी आयोजित केली ज्यामध्ये ग्रँड बक्षीस म्हणून कार होती. आम्ही विश्वास, कौशल्य आणि काळजीने सेवा देत राहतो.",
+
+  "schemesPage.title": "आमच्या योजना"
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: { unoptimized: true }
+  images: { unoptimized: true },
+  i18n: {
+    locales: ["en", "mr"],
+    defaultLocale: "en",
+  },
 };
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js `i18n` for English and Marathi
- add simple translation provider with English and Marathi message files
- externalize UI strings and add a language toggle to the navbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(couldn't run: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dcff16608333a6dc8fa263f73e56